### PR TITLE
Markov generation is now done in a thread

### DIFF
--- a/markov-generator.js
+++ b/markov-generator.js
@@ -1,0 +1,24 @@
+const MarkovGen = require('markov-generator');
+const workerpool = require('workerpool');
+const mongoose = require('mongoose');
+const connectAndGetSchema = require('./mongo-connector');
+require('dotenv').config();
+
+const MessageSchema = connectAndGetSchema();
+const Message = new mongoose.model('Message', MessageSchema);
+
+async function markov(chatId) {
+    const messages = await Message.find({chatId});
+    const input = messages.map(m => {
+        return m.text;
+    });
+    let markov = new MarkovGen({
+        input,
+        minLength: 4
+    });
+    return markov.makeChain();
+}
+
+workerpool.worker({
+    markov
+});

--- a/mongo-connector.js
+++ b/mongo-connector.js
@@ -1,0 +1,21 @@
+const mongoose = require('mongoose');
+const mongooseFieldEncryption = require("mongoose-field-encryption").fieldEncryption;
+
+/**
+ * Connects current thread to mongodb
+ * @returns MongoDBSchema
+ */
+module.exports = () => {
+    console.log("Okay, let's see what I've learnt...")
+    mongoose.connect(`mongodb://${process.env.DB_HOST}:27017/martebot`, { useNewUrlParser: true, useUnifiedTopology: true })
+        .then(() => console.log("Interesting..."))
+        .catch(() => {
+            console.log("Whoops... Something went wrong");
+        });
+    const MessageSchema = new mongoose.Schema({
+        text: String,
+        chatId: Number
+    });
+    MessageSchema.plugin(mongooseFieldEncryption, { fields: ["text"], secret: process.env.ENCRYPT_KEY });
+    return MessageSchema;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "marte-markov-telegram-bot",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1189,6 +1189,11 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
       "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+    },
+    "workerpool": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A=="
     },
     "wrap-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "markov-generator": "^1.2.3",
     "mongoose": "^5.11.15",
     "mongoose-field-encryption": "^4.0.1",
-    "node-telegram-bot-api": "^0.51.0"
+    "node-telegram-bot-api": "^0.51.0",
+    "workerpool": "^6.2.0"
   }
 }


### PR DESCRIPTION
This Pull Request aims to improve the bot responsiveness by off-loading the most time-consuming task (Markov generation) to a worker (pool)

## The problem
As most programming languages, Node.JS only has one thread by default. This means that node apps can only do one thing at a time. This is not exactly true as async IO exists. But it's true for the most part.
More specifically, if the bot is generating the markov output for any chat, the main (and only) thread cannot do anything else. This means that while generating output, the bot may not be able to reply to /help /start or any other requests until markov has finished.

For chats with few learnt messages this is not a problem, since the markov generation algorithm is fast enough. But once we have a lot of messages in a single chatroom this approach starts to show its problems. And not only for the chatroom users but for all bot users

## Proposed solution.
My solution would be off-loading markov generation to a worker(thread) pool. This way we achieve different things:

1. As markov generation is handled by workers, main thread is free. Which means the main thread can still reply to /help and all non-markov commands while the markov chain is generated in background
2. Since this is not a worker, but a worker pool, we can in fact generate several outputs at once if we have the proper arch. This means that the bot should now be faster in multi-core environments.
3. It being a worker pool also means that if a chat has a lot of messages a worker is allocated to it. If then another chat with few messages wants an output too it will get it quick. As a new worker would be assigned to it.

Please feel free to suggest any changes. Even to plainly reject this PR.
Thanks.