### PR TITLE
Avoid learning messages consisting only in a link

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,8 @@ const generateSpeech = async (chatId, length) => {
 }
 
 bot.on('message', (msg) => {
-    if (msg.text && !msg.text.startsWith('/') && !isRemoveOption(msg)){
+    if (msg.text && !msg.text.startsWith('/') && !isRemoveOption(msg)
+    && !/^ *(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*) *$/.test(msg.text)){
         Message.create({
             text: msg.text.replace(new RegExp(`@${process.env.TELEGRAM_BOT_USER}`, 'g'), ''),
             chatId: msg.chat.id


### PR DESCRIPTION
This PR makes the bot ignore messages consisting only in a link.

In some groups loads of links are sent. This links are not really useful for the learning process (at least when they're alone) and only end up using resources with no benefits.

Please feel free to reject this PR or suggest any changes.