### PR TITLE
Avoid replying to other commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,9 +162,9 @@ const generateSpeech = async (chatId, length) => {
 const onCommand = async (regex, callback) => {
     const namedCommandRegex = /\/\w+@/;
     const namedToMeCommandRegex = new RegExp('\\/\\w+@' + process.env.TELEGRAM_BOT_USER);
-    bot.onText(regex, (msg) => {
+    bot.onText(regex, (msg, match) => {
         if (msg.text.match(namedCommandRegex) == null || msg.text.match(namedToMeCommandRegex) != null) {
-            callback(msg);
+            callback(msg, match);
         }
     });
 }

--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ const onCommand = async (regex, callback) => {
     const namedCommandRegex = /\/\w+@/;
     const namedToMeCommandRegex = new RegExp('\\/\\w+@' + process.env.TELEGRAM_BOT_USER);
     bot.onText(regex, (msg) => {
-        if (msg.text.match(namedCommandRegex).length === 0 || msg.text.match(namedToMeCommandRegex).length > 0) {
+        if (msg.text.match(namedCommandRegex) == null || msg.text.match(namedToMeCommandRegex) != null) {
             callback(msg);
         }
     });


### PR DESCRIPTION
This pull request aims to avoid Marte replying to commands not directed at it.

## Problem
Marte will always reply to a command, even if it's not directed at it and it was indeed for another bot.
This is specially a problem if you run two different instances of the bot in the same group. It's also a problem if you have several bots and you try to use the /help command which almost every bot implements. Since Marte will steal the spotlight and answer to the command anyway

## Proposed solution
Use two regular expressions to check whether Marte should reply to the command. If the command either:
1. Isn't directed at anyone `/help`
2. It's directed a Marte `/help@marte`
It will reply.

On the contrary. If it is directed at another bot `/help@uwufyer` Marte won't reply.

Feel free to reject this PR and to request any changes.
Thanks.