### PR TITLE
Added backup/restore funcionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ npm start
 
 To try it out, you can add the [bot](https://telegram.me/iammartebot) to any of your Telegram groups!
 
-## Roadmap
-
-In future releases, MarTe will allow you to export all the knowledge from a group in a file and import it in another group.
-
 ## Release History
 * 0.2.0
     * ADD: Voice messages with the /audio command 

--- a/index.js
+++ b/index.js
@@ -381,9 +381,11 @@ bot.on('callback_query', async (query) => {
             } else if (isJSONFile(query.message.reply_to_message.document)) {
                 learnJSON(chatId, query.message.reply_to_message.document)
             }
+            bot.deleteMessage(chatId, query.message.message_id);
             break;
         case 'data2':
             bot.sendMessage(chatId, 'Okay, maybe next time.');
+            bot.deleteMessage(chatId, query.message.message_id);
             break;
         case 'data3':
             const admins = await bot.getChatAdministrators(chatId);
@@ -393,14 +395,16 @@ bot.on('callback_query', async (query) => {
                     return m.text;
                 });
                 bot.sendDocument(chatId, Buffer.from(JSON.stringify(input)), {}, {contentType: 'application/json', filename: 'history.json'});
+                bot.deleteMessage(chatId, query.message.message_id);
             } else {
                 bot.answerCallbackQuery(query.id, {text: 'Sorry, only admins can make the backups'});
             }
+            break;
         default:
+            bot.deleteMessage(chatId, query.message.message_id);
             break;
     }
     // Remove inline keyboard
-    bot.deleteMessage(chatId, query.message.message_id);
 });
 
 const learnText = (chatId, document) => {
@@ -521,7 +525,7 @@ onCommand(/\/backup/, async (msg) => {
     if (admins.some(adm => adm.user.id === msg.from.id)) {
         askToConfirmBackup(msg);
     } else {
-        bot.sendMessage("Only administrators can ask for backup");
+        bot.sendMessage(chatId, "Only administrators can ask for backup");
     }
 })
 

--- a/index.js
+++ b/index.js
@@ -424,10 +424,18 @@ const learnText = (chatId, document) => {
 
 const learnJSON = async (chatId, document) => {
     const stream = bot.getFileStream(document.file_id);
+    let fullStr = '';
     stream.on('data', (data) => {
         try {
             const str = data.toString();
-            const arr = JSON.parse(str);
+            fullStr += str;
+        } catch (e) {
+            bot.sendMessage(chatId, 'Sorry I couldn\'t learnt it. Does it have the right format?');
+        }
+    });
+    stream.on('end', () => {
+        try {
+            const arr = JSON.parse(fullStr);
             arr.forEach(element => {
                 Message.create({
                     text: element.replace(new RegExp(`@${process.env.TELEGRAM_BOT_USER}`, 'g'), ''),
@@ -438,7 +446,7 @@ const learnJSON = async (chatId, document) => {
         } catch (e) {
             bot.sendMessage(chatId, 'Sorry I couldn\'t learnt it. Does it have the right format?');
         }
-    });
+    })
 }
 
 const isTxtFile = (document) => {

--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ const onCommand = async (regex, callback) => {
     const namedCommandRegex = /\/\w+@/;
     const namedToMeCommandRegex = new RegExp('\\/\\w+@' + process.env.TELEGRAM_BOT_USER);
     bot.onText(regex, (msg) => {
-        if (msg.text.match(namedCommandRegex).length === 0 || msg.text.match(namedToMeCommandRegex).length > 0) {
+        if (msg.text.match(namedCommandRegex) == null || msg.text.match(namedToMeCommandRegex) != null) {
             callback(msg);
         }
     });


### PR DESCRIPTION
This PR aims to add a backup/restore functionality to Marte. This depends on #8 as it includes code from that PR

## Problem
Some times, users may want to  move the learned messages. This may be done to switch across Marte instances (like from Marte to Pluto) or to switch across groups (friends having two different groups and want to carry progress over).

## Proposed solution
The proposed solution includes two new things.
1. A new command named `/backup` which upon invocation will return a JSON containing all learnt messages.
2. Adding functionality to `/learn` so Marte can learn from a generated JSON returned by `/backup`.

## Privacy concerns.
The backup may include information from a long time ago or even removed messages. That's why the `/backup` command may only be used by the Chat Administrators.

Thanks.